### PR TITLE
fix: Don't change item when window is closed

### DIFF
--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -74,6 +74,8 @@ namespace MarketBoardPlugin.GUI
 
     private bool hasHistoryHQColumnWidthBeenSet = false;
 
+    public bool IsOpen { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MarketBoardWindow"/> class.
     /// </summary>
@@ -586,17 +588,20 @@ namespace MarketBoardPlugin.GUI
       this.itemIsBeingHovered = true;
       this.hoveredItemChangeTokenSource = new CancellationTokenSource();
 
-      Task.Run(async () =>
+      if (this.IsOpen)
       {
-        try
+        Task.Run(async () =>
         {
-          await Task.Delay(1000, this.hoveredItemChangeTokenSource.Token).ConfigureAwait(false);
-          this.ChangeSelectedItem(Convert.ToInt32(itemId >= 1000000 ? itemId - 1000000 : itemId));
-        }
-        catch (TaskCanceledException)
-        {
-        }
-      });
+          try
+          {
+            await Task.Delay(1000, this.hoveredItemChangeTokenSource.Token).ConfigureAwait(false);
+            this.ChangeSelectedItem(Convert.ToInt32(itemId >= 1000000 ? itemId - 1000000 : itemId));
+          }
+          catch (TaskCanceledException)
+          {
+          }
+        });
+      }
     }
 
     private void RefreshMarketData()

--- a/MarketBoardPlugin/MBPlugin.cs
+++ b/MarketBoardPlugin/MBPlugin.cs
@@ -31,8 +31,6 @@ namespace MarketBoardPlugin
   {
     private bool isDisposed;
 
-    private bool isImguiMarketBoardWindowOpen = false;
-
     private MarketBoardWindow marketBoardWindow;
 
     private DalamudPluginInterface pluginInterface;
@@ -57,7 +55,7 @@ namespace MarketBoardPlugin
       pluginInterface.Subscribe("ItemSearchPlugin", this.ItemSearchPluginIPC);
 
       #if DEBUG
-      this.isImguiMarketBoardWindowOpen = true;
+      this.marketBoardWindow.IsOpen = true;
       #endif
     }
 
@@ -94,14 +92,14 @@ namespace MarketBoardPlugin
 
     private void OnOpenMarketBoardCommand(string command, string arguments)
     {
-      this.isImguiMarketBoardWindowOpen = true;
+      this.marketBoardWindow.IsOpen = true;
     }
 
     private void BuildMarketBoardUi()
     {
-      if (this.isImguiMarketBoardWindowOpen)
+      if (this.marketBoardWindow != null && this.marketBoardWindow.IsOpen)
       {
-        this.isImguiMarketBoardWindowOpen = this.marketBoardWindow != null && this.marketBoardWindow.Draw();
+        this.marketBoardWindow.IsOpen = this.marketBoardWindow.Draw();
       }
     }
 
@@ -119,7 +117,7 @@ namespace MarketBoardPlugin
         else if (message.Action == "OpenMarketBoard")
         {
           this.marketBoardWindow.ChangeSelectedItem((int)message.ItemId);
-          this.isImguiMarketBoardWindowOpen = true;
+          this.marketBoardWindow.IsOpen = true;
         }
       }
     }


### PR DESCRIPTION
I tried to make this change as low-impact as possible by moving the `isImguiMarketBoardWindowOpen` flag to the `MarketBoardWindow` class, though it's not the cleanest way.

Fixes #3.