### PR TITLE
Bug fixes : Hovering now doesn't depends on search filters anymore + min window size

### DIFF
--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -827,7 +827,7 @@ namespace MarketBoardPlugin.GUI
 
       var item = MBPlugin.Data.Excel.GetSheet<Item>().GetRow((uint)itemId % 500000);
 
-      if (item != null && this.enumerableCategoriesAndItems != null && this.sortedCategoriesAndItems.Any(i => i.Value != null && i.Value.Contains(item)))
+      if (item != null && this.enumerableCategoriesAndItems != null && this.sortedCategoriesAndItems.Any(i => i.Value != null && i.Value.Any(k => k.ToString() == item.ToString())))
       {
         this.itemBeingHovered = itemId;
       }

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -160,7 +160,7 @@ namespace MarketBoardPlugin.GUI
 
       // Window Setup
       ImGui.SetNextWindowSize(new Vector2(800, 600) * scale, ImGuiCond.FirstUseEver);
-      ImGui.SetNextWindowSizeConstraints(new Vector2(700, 450) * scale, new Vector2(10000, 10000) * scale);
+      ImGui.SetNextWindowSizeConstraints(new Vector2(350, 225) * scale, new Vector2(10000, 10000) * scale);
 
       if (!ImGui.Begin($"Market Board", ref windowOpen, ImGuiWindowFlags.NoScrollbar))
       {

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -827,7 +827,7 @@ namespace MarketBoardPlugin.GUI
 
       var item = MBPlugin.Data.Excel.GetSheet<Item>().GetRow((uint)itemId % 500000);
 
-      if (item != null && this.enumerableCategoriesAndItems != null && this.enumerableCategoriesAndItems.Any(i => i.Value != null && i.Value.Contains(item)))
+      if (item != null && this.enumerableCategoriesAndItems != null && this.sortedCategoriesAndItems.Any(i => i.Value != null && i.Value.Contains(item)))
       {
         this.itemBeingHovered = itemId;
       }


### PR DESCRIPTION
Fix the issue #31 

As the title say, hovering now should work even when the item hovered over doesn't match the search filters 