### PR TITLE
New advanced search option : HQ Only

### DIFF
--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -76,6 +76,8 @@ namespace MarketBoardPlugin.GUI
 
     private bool priceIconShown = true;
 
+    private bool hQOnly;
+
     private ulong playerId;
 
     private int selectedWorld = -1;
@@ -219,7 +221,11 @@ namespace MarketBoardPlugin.GUI
       {
         ImGui.Text("Category: ");
         ImGui.SameLine();
-        ImGui.ListBox("###ListBox", ref this.itemCategory, this.categoryLabels, this.categoryLabels.Length);
+        // ImGui.ListBox("###ListBox", ref this.itemCategory, this.categoryLabels, this.categoryLabels.Length);
+        ImGui.Combo("###ListBox", ref this.itemCategory, this.categoryLabels, this.categoryLabels.Length);
+        ImGui.Text("HQ Only : ");
+        ImGui.SameLine();
+        ImGui.Checkbox("###Checkbox", ref this.hQOnly);
         if (this.itemCategory is 1 or 2)
         {
           ImGui.Text("Min level : ");

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -221,7 +221,6 @@ namespace MarketBoardPlugin.GUI
       {
         ImGui.Text("Category: ");
         ImGui.SameLine();
-        // ImGui.ListBox("###ListBox", ref this.itemCategory, this.categoryLabels, this.categoryLabels.Length);
         ImGui.Combo("###ListBox", ref this.itemCategory, this.categoryLabels, this.categoryLabels.Length);
         ImGui.Text("HQ Only : ");
         ImGui.SameLine();
@@ -462,7 +461,7 @@ namespace MarketBoardPlugin.GUI
             ImGui.NextColumn();
             ImGui.Separator();
 
-            var marketDataListings = this.marketData?.Listings.OrderBy(l => l.PricePerUnit).ToList();
+            var marketDataListings = this.marketData?.Listings.Where(i => !this.hQOnly || i.Hq).OrderBy(l => l.PricePerUnit).ToList();
             if (marketDataListings != null)
             {
               foreach (var listing in marketDataListings)


### PR DESCRIPTION
Implement issue #50 

**Changes :**
- New option : HQ Only
Market data will only show HQ items when set as true. The filter will not apply to the recent history tab of the item.
![HQOnly2](https://user-images.githubusercontent.com/45374460/187427448-da6dfd71-dd28-4708-acc4-b1c63cae7d49.png)
- A little cleaner advanced search menu with a Combo object instead of a List object
