### PR TITLE
Shopping List Fix : Correct world attribution + History total price fix

### DIFF
--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -381,7 +381,8 @@ namespace MarketBoardPlugin.GUI
 
                 if (ImGui.Selectable("Add to the shopping list") && this.marketData != null && this.selectedWorld >= 0)
                 {
-                  this.shoppingList.Add(new SavedItem(item, this.marketData.Listings.OrderBy(l => l.PricePerUnit).ToList()[0].PricePerUnit, this.worldList[this.selectedWorld].Item2));
+                  MarketDataListing itm = this.marketData.Listings.OrderBy(l => l.PricePerUnit).ToList()[0];
+                  this.shoppingList.Add(new SavedItem(item, itm.PricePerUnit, itm.WorldName));
                 }
 
                 ImGui.EndPopup();

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -628,7 +628,7 @@ namespace MarketBoardPlugin.GUI
                 }
                 else
                 {
-                  ImGui.Text(history.PricePerUnit.ToString("N0"));
+                  ImGui.Text(history.Total.ToString("N0"));
                 }
 
                 ImGui.NextColumn();


### PR DESCRIPTION
Fix issue #60

Now worlds are correctly displayed inside of the shopping list even in Cross-World and Cross-DC.
![shoppinglist-fix](https://user-images.githubusercontent.com/45374460/188704487-2ef1edd8-04b0-47bc-b18c-522d393664a5.png)
