### PR TITLE
Make compatible with API 8

### DIFF
--- a/MarketBoardPlugin.Tests/MarketBoardPlugin.Tests.csproj
+++ b/MarketBoardPlugin.Tests/MarketBoardPlugin.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows7.0</TargetFramework>
+    <TargetFramework>net7.0-windows7.0</TargetFramework>
     <AssemblyName>MarketBoardPlugin.Tests</AssemblyName>
     <Authors>Florian Maunier</Authors>
     <OutputType>Library</OutputType>

--- a/MarketBoardPlugin.Tests/packages.lock.json
+++ b/MarketBoardPlugin.Tests/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0-windows7.0": {
+    "net7.0-windows7.0": {
       "coverlet.msbuild": {
         "type": "Direct",
         "requested": "[2.8.1, )",
@@ -63,8 +63,8 @@
       },
       "DalamudPackager": {
         "type": "Transitive",
-        "resolved": "2.1.8",
-        "contentHash": "YqagNXs9InxmqkXzq7kLveImxnodkBEicAhydMXVp7dFjC7xb76U6zGgAax4/BWIWfZeWzr5DJyQSev31kj81A=="
+        "resolved": "2.1.10",
+        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
       },
       "Microsoft.CodeAnalysis.VersionCheckAnalyzer": {
         "type": "Transitive",
@@ -606,7 +606,7 @@
         "type": "Project",
         "dependencies": {
           "Dalamud.ContextMenu": "[1.2.1, )",
-          "DalamudPackager": "[2.1.8, )"
+          "DalamudPackager": "[2.1.10, )"
         }
       }
     }

--- a/MarketBoardPlugin/MarketBoardPlugin.csproj
+++ b/MarketBoardPlugin/MarketBoardPlugin.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <AssemblyName>MarketBoardPlugin</AssemblyName>
     <Authors>Florian "fmauNeko" Maunier</Authors>
     <OutputType>Library</OutputType>
@@ -50,7 +50,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dalamud.ContextMenu" Version="1.2.1" />
-    <PackageReference Include="DalamudPackager" Version="2.1.8" />
+    <PackageReference Include="DalamudPackager" Version="2.1.10" />
     <PackageReference Include="MSBuildGitHash" Version="2.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MarketBoardPlugin/packages.lock.json
+++ b/MarketBoardPlugin/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0-windows7.0": {
+    "net7.0-windows7.0": {
       "Dalamud.ContextMenu": {
         "type": "Direct",
         "requested": "[1.2.1, )",
@@ -10,9 +10,9 @@
       },
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.8, )",
-        "resolved": "2.1.8",
-        "contentHash": "YqagNXs9InxmqkXzq7kLveImxnodkBEicAhydMXVp7dFjC7xb76U6zGgAax4/BWIWfZeWzr5DJyQSev31kj81A=="
+        "requested": "[2.1.10, )",
+        "resolved": "2.1.10",
+        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
       },
       "MSBuildGitHash": {
         "type": "Direct",


### PR DESCRIPTION
Bare minimum needed for FFXIV 6.3. 
- .NET7 runtime
- updated dependencies for API 8