### PR TITLE
✨ (mainWindow) open selected item page when clicking Universalis button

### DIFF
--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -719,7 +719,13 @@ namespace MarketBoardPlugin.GUI
       ImGui.SetCursorPosY(ImGui.GetWindowContentRegionMax().Y - ImGui.GetTextLineHeightWithSpacing());
       if (ImGui.Button("Data provided by Universalis"))
       {
-        Utilities.OpenBrowser("https://universalis.app/");
+        var universalisUrl = $"https://universalis.app";
+        if (this.selectedItem != null)
+        {
+          universalisUrl += $"/market/{this.selectedItem.RowId}";
+        }
+
+        Utilities.OpenBrowser(universalisUrl);
       }
 
       ImGui.SameLine(ImGui.GetContentRegionAvail().X - (120 * scale));


### PR DESCRIPTION
Makes it easier to go on the item page when we want more info or sometimes the API is bugged, but the website works.