### PR TITLE
[Features] Marketboard item caching + Universalis fetching data prompt + Recent history option

### DIFF
--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -488,6 +488,13 @@ namespace MarketBoardPlugin.GUI
             $"Last update: {DateTimeOffset.FromUnixTimeMilliseconds(this.marketData.LastUploadTime).LocalDateTime:G}");
           ImGui.SetCursorPosY(ImGui.GetCursorPosY() + ImGui.GetTextLineHeight() - ImGui.GetTextLineHeightWithSpacing());
         }
+        else
+        {
+          ImGui.SetNextItemWidth(250 * scale);
+          ImGui.Text(
+            $"Fetching data from Universalis...");
+          ImGui.SetCursorPosY(ImGui.GetCursorPosY() + ImGui.GetTextLineHeight() - ImGui.GetTextLineHeightWithSpacing());
+        }
 
         ImGui.EndGroup();
 

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -94,6 +94,8 @@ namespace MarketBoardPlugin.GUI
 
     private int marketBufferMaxSize = 10;
 
+    private int oldMarketBufferMaxSize = 10;
+
     private int selectedListing = -1;
 
     private int selectedHistory = -1;
@@ -859,8 +861,15 @@ namespace MarketBoardPlugin.GUI
         this.config.KofiHidden = kofiHidden;
         MBPlugin.PluginInterface.SavePluginConfig(this.config);
       }
+
       ImGui.Text("Number of buffered item : ");
       ImGui.InputInt("###marketBufferSize", ref this.marketBufferMaxSize);
+      if (this.oldMarketBufferMaxSize != this.marketBufferMaxSize)
+      {
+        this.config.MarketBufferSize = this.marketBufferMaxSize;
+        MBPlugin.PluginInterface.SavePluginConfig(this.config);
+        this.oldMarketBufferMaxSize = this.marketBufferMaxSize;
+      }
 
       ImGui.End();
     }
@@ -1135,8 +1144,11 @@ namespace MarketBoardPlugin.GUI
           }
           else
           {
-            if(this.marketData != null)
+            if (this.marketData != null)
+            {
               this.marketBuffer.Add(this.marketData);
+            }
+
             if (this.marketBuffer.Count > this.marketBufferMaxSize)
             {
               this.marketBuffer.RemoveAt(0);

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -90,6 +90,8 @@ namespace MarketBoardPlugin.GUI
 
     private int selectedWorld = -1;
 
+    private int previousSelectedWorld = -1;
+
     private MarketDataResponse marketData;
 
     private List<MarketDataResponse> marketBuffer;
@@ -477,6 +479,7 @@ namespace MarketBoardPlugin.GUI
             var isSelected = this.selectedWorld == this.worldList.IndexOf(world);
             if (ImGui.Selectable(world.Item2, isSelected))
             {
+              this.previousSelectedWorld = this.selectedWorld;
               this.selectedWorld = this.worldList.IndexOf(world);
               this.config.CrossDataCenter = this.selectedWorld == 0;
               this.config.CrossWorld = this.selectedWorld == 1;
@@ -1175,8 +1178,9 @@ namespace MarketBoardPlugin.GUI
           this.marketData = cachedItem;
         }
 
-        if (cachedItem == null || DateTimeOffset.Now.ToUnixTimeMilliseconds() - cachedItem.FetchTimestamp > this.bufferRefreshTimeout)
+        if (cachedItem == null || this.selectedWorld != this.previousSelectedWorld || DateTimeOffset.Now.ToUnixTimeMilliseconds() - cachedItem.FetchTimestamp > this.bufferRefreshTimeout)
         {
+          this.previousSelectedWorld = this.selectedWorld;
           if (cachedItem == null)
           {
             if (this.marketData != null)

--- a/MarketBoardPlugin/Helpers/UniversalisClient.cs
+++ b/MarketBoardPlugin/Helpers/UniversalisClient.cs
@@ -41,6 +41,10 @@ namespace MarketBoardPlugin.Helpers
       var parsedRes = await JsonSerializer
         .DeserializeAsync<MarketDataResponse>(res, cancellationToken: cancellationToken)
         .ConfigureAwait(false);
+      if (parsedRes != null)
+      {
+        parsedRes.FetchTimestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+      }
 
       return parsedRes;
     }

--- a/MarketBoardPlugin/MBPluginConfig.cs
+++ b/MarketBoardPlugin/MBPluginConfig.cs
@@ -53,5 +53,10 @@ namespace MarketBoardPlugin
     /// Gets or sets a value indicating whether the Ko-Fi button has been hidden.
     /// </summary>
     public bool KofiHidden { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating the maximum size of the Market item buffer.
+    /// </summary>
+    public int MarketBufferSize { get; set; } = 10;
   }
 }

--- a/MarketBoardPlugin/MBPluginConfig.cs
+++ b/MarketBoardPlugin/MBPluginConfig.cs
@@ -58,5 +58,10 @@ namespace MarketBoardPlugin
     /// Gets or sets a value indicating the maximum size of the Market item buffer.
     /// </summary>
     public int MarketBufferSize { get; set; } = 10;
+
+    /// <summary>
+    ///  Gets or sets the number of ms an item can be cached.
+    /// </summary>
+    public int ItemRefreshTimeout { get; set; } = 30000;
   }
 }

--- a/MarketBoardPlugin/MBPluginConfig.cs
+++ b/MarketBoardPlugin/MBPluginConfig.cs
@@ -60,8 +60,13 @@ namespace MarketBoardPlugin
     public int MarketBufferSize { get; set; } = 10;
 
     /// <summary>
-    ///  Gets or sets the number of ms an item can be cached.
+    ///  Gets or sets a value indicating the number of ms an item can be cached.
     /// </summary>
     public int ItemRefreshTimeout { get; set; } = 30000;
+
+    /// <summary>
+    ///  Gets or sets a value indicating whether the recent history menu is disabled or not.
+    /// </summary>
+    public bool RecentHistoryDisabled { get; set; } = false;
   }
 }

--- a/MarketBoardPlugin/Models/Universalis/MarketDataResponse.cs
+++ b/MarketBoardPlugin/Models/Universalis/MarketDataResponse.cs
@@ -82,6 +82,11 @@ namespace MarketBoardPlugin.Models.Universalis
     public double SaleVelocityHq { get; set; }
 
     /// <summary>
+    /// Gets or sets the fetch timestamp.
+    /// </summary>
+    public long FetchTimestamp { get; set; }
+
+    /// <summary>
     /// Gets the stack size histogram.
     /// </summary>
     [JsonPropertyName("stackSizeHistogram")]


### PR DESCRIPTION
Changes (#70 and #69) : 
- Added an item buffer that allows to save the last N(by default 10) items fetched from the Universalis API. If the API shutdowns, these saved items should still be accessible.
![Buff](https://user-images.githubusercontent.com/45374460/217676860-a03bf32b-df4e-4d1f-89d4-dee1bd9025f6.PNG)
The buffer is not saved between each game restart, the main benefits are that it reduces the number of request on the Universalis API when the same items are checked multiple times, and that if the Universalis API disconnect while playing the user can still look at their last searches.
Each item of this buffer will get re-fetched after a certain timeout by default 30 seconds. This setting can also be modified :
![new_settings](https://user-images.githubusercontent.com/45374460/217694180-4bd76c80-7cd8-45cc-ab6e-78774b9fa659.png)

- A prompt is added when new data is fetched : 
![view](https://user-images.githubusercontent.com/45374460/217676979-6d6856c9-ce79-46b9-9351-05a75591b88f.png)
- The last time an item has been fetched is also displayed :
![new_ui](https://user-images.githubusercontent.com/45374460/217694794-b83ddbc7-0246-46a8-a6fe-44ab0614c73b.png)
- Bonus feature (#63) : 
![bonusfeature](https://user-images.githubusercontent.com/45374460/217699331-d61e8ecf-c5ef-4c22-a9a7-2736385f325b.png)
