### PR TITLE
Shopping List stays open and add the option to disable Gil Sales Tax

### DIFF
--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -862,7 +862,7 @@ namespace MarketBoardPlugin.GUI
         MBPlugin.PluginInterface.SavePluginConfig(this.config);
       }
 
-      if (ImGui.Checkbox("No Gil Sales Taxt", ref this.noGilSalesTax))
+      if (ImGui.Checkbox("No Gil Sales Tax", ref this.noGilSalesTax))
       {
         this.config.NoGilSalesTax = this.noGilSalesTax;
         MBPlugin.PluginInterface.SavePluginConfig(this.config);

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -791,11 +791,6 @@ namespace MarketBoardPlugin.GUI
         this.OpenSettingMenu();
       }
 
-      if (this.shoppingList.Count > 0)
-      {
-        this.ShowShoppingListMenu();
-      }
-
       return windowOpen;
     }
 
@@ -917,8 +912,13 @@ namespace MarketBoardPlugin.GUI
     /// <summary>
     /// Create a new separate window showing the shopping list.
     /// </summary>
-    private void ShowShoppingListMenu()
+    public void ShowShoppingListMenu()
     {
+      if (this.shoppingList.Count == 0)
+      {
+        return;
+      }
+
       var scale = ImGui.GetIO().FontGlobalScale;
 
       ImGui.SetNextWindowSize(new Vector2(400, 150) * scale, ImGuiCond.FirstUseEver);

--- a/MarketBoardPlugin/GUI/MarketBoardWindow.cs
+++ b/MarketBoardPlugin/GUI/MarketBoardWindow.cs
@@ -80,6 +80,8 @@ namespace MarketBoardPlugin.GUI
 
     private bool priceIconShown = true;
 
+    private bool noGilSalesTax = false;
+
     private bool recentHistoryDisabled = false;
 
     private bool hQOnly;
@@ -156,6 +158,7 @@ namespace MarketBoardPlugin.GUI
       this.bufferRefreshTimeout = this.config.ItemRefreshTimeout;
       this.marketBufferMaxSize = this.config.MarketBufferSize;
       this.recentHistoryDisabled = this.config.RecentHistoryDisabled;
+      this.noGilSalesTax = this.config.NoGilSalesTax;
 
       this.numberFormatInfo = (NumberFormatInfo)CultureInfo.CurrentCulture.NumberFormat.Clone();
       this.numberFormatInfo.CurrencySymbol = SeIconChar.Gil.ToIconString();
@@ -859,6 +862,14 @@ namespace MarketBoardPlugin.GUI
         MBPlugin.PluginInterface.SavePluginConfig(this.config);
       }
 
+      if (ImGui.Checkbox("No Gil Sales Taxt", ref this.noGilSalesTax))
+      {
+        this.config.NoGilSalesTax = this.noGilSalesTax;
+        MBPlugin.PluginInterface.SavePluginConfig(this.config);
+        this.marketBuffer.Clear();
+        this.RefreshMarketData();
+      }
+
       if (ImGui.Checkbox("Disable Recent History", ref this.recentHistoryDisabled))
       {
         this.config.RecentHistoryDisabled = this.recentHistoryDisabled;
@@ -1204,7 +1215,7 @@ namespace MarketBoardPlugin.GUI
 
           this.marketData = await UniversalisClient
             .GetMarketData(this.selectedItem.RowId, this.worldList[this.selectedWorld].Item1, 50,
-              CancellationToken.None)
+              this.noGilSalesTax, CancellationToken.None)
             .ConfigureAwait(false);
 
           if (cachedItem != null)

--- a/MarketBoardPlugin/Helpers/UniversalisClient.cs
+++ b/MarketBoardPlugin/Helpers/UniversalisClient.cs
@@ -25,9 +25,9 @@ namespace MarketBoardPlugin.Helpers
     /// <param name="historyCount">Number of entries to fetch from the history.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>The market data.</returns>
-    public static async Task<MarketDataResponse> GetMarketData(uint itemId, string worldName, int historyCount, CancellationToken cancellationToken)
+    public static async Task<MarketDataResponse> GetMarketData(uint itemId, string worldName, int historyCount, bool noGST, CancellationToken cancellationToken)
     {
-      var uriBuilder = new UriBuilder($"https://universalis.app/api/{worldName}/{itemId}?entries={historyCount}");
+      var uriBuilder = new UriBuilder($"https://universalis.app/api/{worldName}/{itemId}?entries={historyCount}&noGST={Convert.ToInt16(noGST)}");
 
       cancellationToken.ThrowIfCancellationRequested();
 

--- a/MarketBoardPlugin/MBPlugin.cs
+++ b/MarketBoardPlugin/MBPlugin.cs
@@ -191,9 +191,13 @@ namespace MarketBoardPlugin
 
     private void BuildMarketBoardUi()
     {
-      if (this.marketBoardWindow != null && this.marketBoardWindow.IsOpen)
+      if (this.marketBoardWindow != null)
       {
-        this.marketBoardWindow.IsOpen = this.marketBoardWindow.Draw();
+        if (this.marketBoardWindow.IsOpen)
+        {
+          this.marketBoardWindow.IsOpen = this.marketBoardWindow.Draw();
+        }
+        this.marketBoardWindow.ShowShoppingListMenu();
       }
     }
   }

--- a/MarketBoardPlugin/MBPluginConfig.cs
+++ b/MarketBoardPlugin/MBPluginConfig.cs
@@ -50,6 +50,11 @@ namespace MarketBoardPlugin
     public bool PriceIconShown { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether 'NoGilSalesTax' is enabled.
+    /// </summary>
+    public bool NoGilSalesTax { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets a value indicating whether the Ko-Fi button has been hidden.
     /// </summary>
     public bool KofiHidden { get; set; } = false;


### PR DESCRIPTION
  - Now the shopping list will stay open as long as it has item stored even if the main window is closed.
  - Added the option to show prices without the Gil Sale Tax
 
Solve #79 & #76 

Demo

https://github.com/fmauNeko/MarketBoardPlugin/assets/45374460/5cea7ded-4ae2-4890-8414-df954764250a

