### PR TITLE
don't show ctx menu entry on irrelevant items

### DIFF
--- a/MarketBoardPlugin/MBPlugin.cs
+++ b/MarketBoardPlugin/MBPlugin.cs
@@ -277,6 +277,11 @@ namespace MarketBoardPlugin
         return;
       }
 
+      if (item.Value.IsUntradable)
+      {
+        return;
+      }
+
       args.AddMenuItem(new MenuItem
       {
         Name = "Search in Market Board",


### PR DESCRIPTION
I know you disable the entry but it really shouldn't be there in the first place.